### PR TITLE
Allow python build with recent tkinter

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -772,7 +772,7 @@ build_package_standard_build() {
       export CC=clang
     fi
     ${!PACKAGE_CONFIGURE:-./configure} --prefix="${!PACKAGE_PREFIX_PATH:-$PREFIX_PATH}" \
-      $CONFIGURE_OPTS ${!PACKAGE_CONFIGURE_OPTS} "${!PACKAGE_CONFIGURE_OPTS_ARRAY}" || return 1
+        $CONFIGURE_OPTS --with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6' ${!PACKAGE_CONFIGURE_OPTS} "${!PACKAGE_CONFIGURE_OPTS_ARRAY}" || return 1
   ) >&4 2>&1
 
   { "$MAKE" $MAKE_OPTS ${!PACKAGE_MAKE_OPTS} "${!PACKAGE_MAKE_OPTS_ARRAY}"

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -78,11 +78,11 @@ assert_build_log() {
 
   assert_build_log <<OUT
 yaml-0.1.6: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-yaml-0.1.6: --prefix=$INSTALL_ROOT
+yaml-0.1.6: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6
 make -j 2
 make install
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -110,12 +110,12 @@ OUT
 
   assert_build_log <<OUT
 yaml-0.1.6: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-yaml-0.1.6: --prefix=$INSTALL_ROOT
+yaml-0.1.6: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6
 make -j 2
 make install
 patch -p0 --force -i $TMP/python-patch.XXX
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -143,12 +143,12 @@ OUT
 
   assert_build_log <<OUT
 yaml-0.1.6: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-yaml-0.1.6: --prefix=$INSTALL_ROOT
+yaml-0.1.6: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6
 make -j 2
 make install
 patch -p1 --force -i $TMP/python-patch.XXX
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -177,7 +177,7 @@ OUT
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I$brew_libdir/include -I${TMP}/install/include " LDFLAGS="-L$brew_libdir/lib -L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -205,7 +205,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I$readline_libdir/include -I${TMP}/install/include " LDFLAGS="-L$readline_libdir/lib -L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -236,7 +236,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT CPPFLAGS=-I$readline_libdir/include LDFLAGS=-L$readline_libdir/lib --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 CPPFLAGS=-I$readline_libdir/include LDFLAGS=-L$readline_libdir/lib --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -267,7 +267,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -299,7 +299,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
 make -j 4
 make install
 OUT
@@ -327,7 +327,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
 make -j 1
 make install
 OUT
@@ -353,7 +353,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install DOGE="such wow"
 OUT
@@ -379,7 +379,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install DOGE="such wow"
 OUT
@@ -474,7 +474,7 @@ DEF
   assert_build_log <<OUT
 apply -p1 -i /my/patch.diff
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -78,11 +78,11 @@ assert_build_log() {
 
   assert_build_log <<OUT
 yaml-0.1.6: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-yaml-0.1.6: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} 
+yaml-0.1.6: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}
 make -j 2
 make install
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -115,7 +115,7 @@ make -j 2
 make install
 patch -p0 --force -i $TMP/python-patch.XXX
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -148,7 +148,7 @@ make -j 2
 make install
 patch -p1 --force -i $TMP/python-patch.XXX
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -177,7 +177,7 @@ OUT
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I$brew_libdir/include -I${TMP}/install/include " LDFLAGS="-L$brew_libdir/lib -L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -205,7 +205,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I$readline_libdir/include -I${TMP}/install/include " LDFLAGS="-L$readline_libdir/lib -L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -236,7 +236,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  CPPFLAGS=-I$readline_libdir/include LDFLAGS=-L$readline_libdir/lib --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} CPPFLAGS=-I$readline_libdir/include LDFLAGS=-L$readline_libdir/lib --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -267,7 +267,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -299,7 +299,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=$INSTALL_ROOT/lib
 make -j 4
 make install
 OUT
@@ -327,7 +327,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=$INSTALL_ROOT/lib
 make -j 1
 make install
 OUT
@@ -353,7 +353,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install DOGE="such wow"
 OUT
@@ -379,7 +379,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install DOGE="such wow"
 OUT
@@ -474,7 +474,7 @@ DEF
   assert_build_log <<OUT
 apply -p1 -i /my/patch.diff
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -78,11 +78,11 @@ assert_build_log() {
 
   assert_build_log <<OUT
 yaml-0.1.6: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-yaml-0.1.6: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6
+yaml-0.1.6: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} 
 make -j 2
 make install
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -110,12 +110,12 @@ OUT
 
   assert_build_log <<OUT
 yaml-0.1.6: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-yaml-0.1.6: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6
+yaml-0.1.6: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}
 make -j 2
 make install
 patch -p0 --force -i $TMP/python-patch.XXX
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -143,12 +143,12 @@ OUT
 
   assert_build_log <<OUT
 yaml-0.1.6: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-yaml-0.1.6: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6
+yaml-0.1.6: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}
 make -j 2
 make install
 patch -p1 --force -i $TMP/python-patch.XXX
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -177,7 +177,7 @@ OUT
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I$brew_libdir/include -I${TMP}/install/include " LDFLAGS="-L$brew_libdir/lib -L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -205,7 +205,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I$readline_libdir/include -I${TMP}/install/include " LDFLAGS="-L$readline_libdir/lib -L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -236,7 +236,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 CPPFLAGS=-I$readline_libdir/include LDFLAGS=-L$readline_libdir/lib --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  CPPFLAGS=-I$readline_libdir/include LDFLAGS=-L$readline_libdir/lib --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -267,7 +267,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -299,7 +299,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
 make -j 4
 make install
 OUT
@@ -327,7 +327,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
 make -j 1
 make install
 OUT
@@ -353,7 +353,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install DOGE="such wow"
 OUT
@@ -379,7 +379,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install DOGE="such wow"
 OUT
@@ -474,7 +474,7 @@ DEF
   assert_build_log <<OUT
 apply -p1 -i /my/patch.diff
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install --with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT

--- a/plugins/python-build/test/compiler.bats
+++ b/plugins/python-build/test/compiler.bats
@@ -90,7 +90,7 @@ build_package_standard python
 DEF
   assert_success
   assert_output <<OUT
-./configure --prefix=$INSTALL_ROOT --libdir=${TMP}/install/lib
+./configure --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=${TMP}/install/lib
 CC=clang
 CFLAGS=no
 make -j 2

--- a/plugins/python-build/test/compiler.bats
+++ b/plugins/python-build/test/compiler.bats
@@ -90,7 +90,7 @@ build_package_standard python
 DEF
   assert_success
   assert_output <<OUT
-./configure --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=${TMP}/install/lib
+./configure --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=${TMP}/install/lib
 CC=clang
 CFLAGS=no
 make -j 2

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -124,7 +124,7 @@ run_inline_definition_with_name() {
   assert_build_log <<OUT
 patch -p0 --force -i $TMP/python-patch.XXX
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -124,7 +124,7 @@ run_inline_definition_with_name() {
   assert_build_log <<OUT
 patch -p0 --force -i $TMP/python-patch.XXX
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS}  --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -156,7 +156,7 @@ patch: bar
 patch: baz
 patch: foo
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -182,7 +182,7 @@ OUT
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --libdir=$INSTALL_ROOT/lib
 make -j 2
 make altinstall
 OUT
@@ -305,7 +305,7 @@ EOS
 
   assert_build_log <<OUT
 Python-3.6.2: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.6.2: --prefix=$INSTALL_ROOT --enable-unicode=ucs2 --libdir=$INSTALL_ROOT/lib
+Python-3.6.2: --prefix=${TMP}/install ${WITH_TCLTK_FLAGS} --enable-unicode=ucs2 --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT

--- a/plugins/python-build/test/test_helper.bash
+++ b/plugins/python-build/test/test_helper.bash
@@ -2,9 +2,11 @@ export TMP="$BATS_TEST_DIRNAME/tmp"
 export PYTHON_BUILD_CURL_OPTS=
 export PYTHON_BUILD_HTTP_CLIENT="curl"
 
+
 if [ "$FIXTURE_ROOT" != "$BATS_TEST_DIRNAME/fixtures" ]; then
   export FIXTURE_ROOT="$BATS_TEST_DIRNAME/fixtures"
   export INSTALL_ROOT="$TMP/install"
+  export WITH_TCLTK_FLAGS="--with-tcltk-includes=-I/usr/local/opt/tcl-tk/include --with-tcltk-libs=-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6"
   PATH="/usr/bin:/bin:/usr/sbin:/sbin"
   if [ "FreeBSD" = "$(uname -s)" ]; then
     PATH="/usr/local/bin:$PATH"


### PR DESCRIPTION
 reference pyenv/pyenv#1375

Make sure you have checked all steps below.

### Prerequisite
* [ ] Please consider implementing the feature as a hook script or plugin as a first step.
  * pyenv has some powerful support for plugins and hook scripts. Please refer to [Authoring plugins](https://github.com/pyenv/pyenv/wiki/Authoring-plugins) for details and try to implement it as a plugin if possible.
* [ ] Please consider contributing the patch upstream to [rbenv](https://github.com/rbenv/rbenv), since we have borrowed most of the code from that project.
  * We occasionally import the changes from rbenv. In general, you can expect changes made in rbenv will be imported to pyenv too, eventually.
  * Generally speaking, we prefer not to make changes in the core in order to keep compatibility with rbenv.
* [x] My PR addresses the following pyenv issue (if any)
  - https://github.com/pyenv/pyenv/issues/1375

### Description
- [x] Here are some details about my PR
 reference pyenv/pyenv#1375

### Tests
- [ ] My PR adds the following unit tests (if any)
